### PR TITLE
Add 'hash_length' key for services

### DIFF
--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -129,7 +129,10 @@ class SaasHerder(object):
         continue
       output = ""
       template_file = self.get_template_file(s)
-      tag = "latest" if s["hash"] == "master" else s["hash"][:6]
+      l = 6 #How many chars to use from hash
+      if s.get("hash_length"):
+        l = s.get("hash_length")
+      tag = "latest" if s["hash"] == "master" else s["hash"][:l]
       parameters = [{"name": "IMAGE_TAG", "value": tag}]
       service_params = s.get("parameters", {})
       for key, val in service_params.iteritems():


### PR DESCRIPTION
Bayesian (@msrb) is using 7 characters from `hash` to tag images. Other services use 6 characters. To allow both work correctly without a pile of PRs, `hash_length` is introduced and will be used while shortening the commit `hash` for template processing.