### PR TITLE
Fix service name and rename the file

### DIFF
--- a/dsaas-services/openshift.io.yaml
+++ b/dsaas-services/openshift.io.yaml
@@ -1,5 +1,5 @@
 services:
 - hash: d9e6e97fbf1eb48965499eb03129af4cb51114d4
-  name: www.openshift.io
+  name: openshift.io
   path: /openshift/www.openshift.io.app.yaml
   url: https://github.com/openshiftio/openshift.io


### PR DESCRIPTION
This fix is to match rename of CI job from www.openshift.io-build-master to openshift.io-build-master