### PR TITLE
[bay-services] Temporarily scale workers down to 45

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -4,7 +4,7 @@ services:
   name: worker-ingestion
   parameters:
     WORKER_ADMINISTRATION_REGION: ingestion
-    REPLICAS: 60
+    REPLICAS: 45
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-worker/
 - hash: 7615684618afbd7e6693684feb9775d489d66bb2


### PR DESCRIPTION
worker pre-hooks fail with `Insufficient cpu fit failure on node`. will this help?