### PR TITLE
Update core to fix Github/OSO linking in Keycloak 3.2

### DIFF
--- a/dsaas-services/core.yaml
+++ b/dsaas-services/core.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 805704f45a7b28988afe35f634fa64ee60bd2b8a
+- hash: 5c38e3874338ab3bac8b6bbe0e7fa0ead0d64609
   name: core
   path: /openshift/core.app.yaml
   url: https://github.com/almighty/almighty-core/


### PR DESCRIPTION
We need to switch the rout to dsaas-keycloak project in prod first. Currently sso.openshift.io is still used by the old 3.0.0 deployment.
More details about that issue with KC 3.2 - https://github.com/almighty/almighty-core/issues/1388