### PR TITLE
[bay-services] Bump jobs service, so it contains github auth

### DIFF
--- a/bay-services/jobs.yaml
+++ b/bay-services/jobs.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 74a4ed25d8b55b878d99b183bd7a26a50410dce2
+- hash: 2e86db112e19f16ba229102d0d4e399df99c2aa3
   hash_length: 7
   name: jobs
   path: /openshift/template.yaml


### PR DESCRIPTION
The image was built in Jenkins and pushed https://cucos-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/fabric8-analytics-jobs-master/212/

Credentials required to run this should be upload too.