### PR TITLE
Cap size of RPT in keycloak

### DIFF
--- a/keycloak-services/keycloak.yaml
+++ b/keycloak-services/keycloak.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 588b46286f7b88e56339712180f0320339d79720
+- hash: 15751c889f5099504cfa7256183f59a59a3ef624
   name: keycloak
   path: /openshift/keycloak.app.yaml
   url: https://github.com/fabric8io/keycloak-deployment

--- a/keycloak-services/keycloak.yaml
+++ b/keycloak-services/keycloak.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ac1aca8fa18267c3bc5aea910b8023cddf03f63c
+- hash: 588b46286f7b88e56339712180f0320339d79720
   name: keycloak
   path: /openshift/keycloak.app.yaml
   url: https://github.com/fabric8io/keycloak-deployment


### PR DESCRIPTION
- Move of repo from almighty --> fabric8-services
- Latest changes incl. RPT token limits https://github.com/fabric8-services/keycloak/pull/90
- take commit https://github.com/fabric8io/keycloak-deployment/commit/15751c889f5099504cfa7256183f59a59a3ef624